### PR TITLE
Make mutateSRC work

### DIFF
--- a/Examples/mutateIR.sh
+++ b/Examples/mutateIR.sh
@@ -4,8 +4,8 @@ CURR_DIR=$( cd $( dirname $0 ) && pwd )
 
 # Set up paths to where compiled tools are here
 export SRCIROR_COVINSTRUMENTATION_LIB=$CURR_DIR/../IRMutation/InstrumentationLib/SRCIRORCoverageLib.o
-export SRCIROR_LLVMMutate_LIB=$CURR_DIR/../tools/llvm-build/Release+Asserts/lib/LLVMMutate.so
-export SRCIROR_LLVM_BIN=$CURR_DIR/../tools/llvm-build/Release+Asserts/bin/
+export SRCIROR_LLVMMutate_LIB=$CURR_DIR/../llvm-build/Release+Asserts/lib/LLVMMutate.so
+export SRCIROR_LLVM_BIN=$CURR_DIR/../llvm-build/Release+Asserts/bin/
 
 # generate coverage
 rm -f /tmp/llvm_mutate_trace # remove any existing coverage

--- a/Examples/mutateSRC.sh
+++ b/Examples/mutateSRC.sh
@@ -7,7 +7,7 @@ rm -rf ~/.srciror
 mkdir ~/.srciror
 echo "$CURR_DIR/test.c:3,4,5,6,7,8,9" > ~/.srciror/coverage
 
-SRCIROR_LLVM_BIN=$CURR_DIR/../tools/llvm-build/Release+Asserts/bin
-SRCIROR_LLVM_INCLUDES=$CURR_DIR/../tools/llvm-build/Release+Asserts/lib/clang/3.8.0/include
-SRCIROR_SRC_MUTATOR=$CURR_DIR/../SRCMutation/build/mutator
+export SRCIROR_LLVM_BIN=$CURR_DIR/../llvm-build/Release+Asserts/bin
+export SRCIROR_LLVM_INCLUDES=$CURR_DIR/../llvm-build/Release+Asserts/lib/clang/3.8.0/include
+export SRCIROR_SRC_MUTATOR=$CURR_DIR/../SRCMutation/build/mutator
 python $CURR_DIR/../PythonWrappers/mutationClang $CURR_DIR/test.c -o test


### PR DESCRIPTION
Fixes wrong paths and adds export-statements that are necessary on my system.

mutateIR is still not working because it is using the `../tools` directory
instead of just `../`, somewhere, but I couldn't find the location, unfortunately.