### PR TITLE
Add some clarifications to README, make README.md proper markdown

### DIFF
--- a/IRMutation/README
+++ b/IRMutation/README
@@ -1,9 +1,12 @@
 Instructions for compiling the LLVM passes:
 
-- copy the directory called Mutation (under LLVMPasses) as is into the
-  LLVM source code tree under lib/Transforms/
+- copy the directory called Mutation (under ./LLVMPasses) as is into the
+  LLVM source code tree under lib/Transforms/.
+  (if you used build-llvm.sh to install LLVM locally,
+  the directory will be ../llvm/lib/Transforms/)
 - add our new mutation pass (Mutation) into the make files under lib/Transforms.
-(either copy the provided Makefile and CMakeLists.txt into lib/Transforms
+(either copy the provided Makefile and CMakeLists.txt from this directory
+to lib/Transforms
 if using LLVM 3.8.1 or adapt the existing ones if using another version)
 - go to your LLVM build directory and rebuild. You should have the mutation
 library generated under $build_directory/Release+Asserts/lib/LLVMMutate.so

--- a/README.md
+++ b/README.md
@@ -29,5 +29,5 @@ BUILDING:
       export SRCIROR_COVINSTRUMENTATION_LIB=${PATH_TO_SRCIROR_DIR}/InstrumentationLib/SRCIRORCoverageLib.o;
     ```
   Either set environment variables `PATH_TO_LLVM_BUILD` and `PATH_TO_SRCIROR_DIR`,
-  or replace them with the corresponding values in the statements below.
+  or replace them with the corresponding values in the statements above.
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,32 @@
 SRCIROR (pronounced sorcerer) is a SRC and IR mutatOR. It performs mutations on source code written in C/C++ and on the LLVM IR.
 
 BUILDING:
-(0) Need dependencies:
+
+  0. Need dependencies:
         python
         python3
         clang
         lib32z1-dev
 
-(1) Build LLVM locally (if you do not already have it built). You can executed the provided script:
-        ./llvm-build.sh
-    This creates llvm/ and llvm-build/ directories
+  1. Build LLVM locally (if you do not already have it built). You can execute the provided script:  
+        `./llvm-build.sh`  
+    This creates llvm/ and llvm-build/ directories.
 
-(2) Build the SRC mutator. To build SRC mutator, see SRCMutation/README.
+  2. Build the SRC mutator. To build SRC mutator, see SRCMutation/README.
 
-(3) Build the IR mutator. To build IR mutator, see IRMutation/README.
+  3. Build the IR mutator. To build IR mutator, see IRMutation/README.
 
-(4) Build the IR instrumentation code.
-        cd IRMutation/InstrumentationLib/; ./build-lib.sh
+  4. Build the IR instrumentation code:  
+        `cd IRMutation/InstrumentationLib/; ./build-lib.sh`
 
-(5) Set up the environment variables needed by SRCIROR:
-        export SRCIROR_LLVMMutate_LIB=${PATH_TO_LLVM_BUILD}/Release+Asserts/lib/LLVMMutate.so
-        export SRCIROR_SRC_MUTATOR=${PATH_TO_SRCIROR_DIR}/SRCMutation/build/mutator
-        export SRCIROR_LLVM_BIN=${PATH_TO_LLVM_BUILD}/Release+Asserts/bin/
-        export SRCIROR_LLVM_INCLUDES=${PATH_TO_LLVM_BUILD}/Release+Asserts/lib/clang/3.8.0/include/
-        export SRCIROR_COVINSTRUMENTATION_LIB=${PATH_TO_SRCIROR_DIR}/InstrumentationLib/SRCIRORCoverageLib.o
+  5. Set up the environment variables needed by SRCIROR. 
+    ```bash
+      export SRCIROR_LLVMMutate_LIB=${PATH_TO_LLVM_BUILD}/Release+Asserts/lib/LLVMMutate.so;
+      export SRCIROR_SRC_MUTATOR=${PATH_TO_SRCIROR_DIR}/SRCMutation/build/mutator;
+      export SRCIROR_LLVM_BIN=${PATH_TO_LLVM_BUILD}/Release+Asserts/bin/;
+      export SRCIROR_LLVM_INCLUDES=${PATH_TO_LLVM_BUILD}/Release+Asserts/lib/clang/3.8.0/include/;
+      export SRCIROR_COVINSTRUMENTATION_LIB=${PATH_TO_SRCIROR_DIR}/InstrumentationLib/SRCIRORCoverageLib.o;
+    ```
+  Either set environment variables `PATH_TO_LLVM_BUILD` and `PATH_TO_SRCIROR_DIR`,
+  or replace them with the corresponding values in the statements below.
 


### PR DESCRIPTION
When trying out srciror, I was uncertain about some minor things,
so I tried to clarify them in the README.

I also made the README.md proper markdown, so that supporting editors and GitHub can render it as markdown or use apprioriate syntax highlighting -- this pull request is just in case you want these changes.